### PR TITLE
Apex Truth 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ even when the subclass instance is cast as the superclass
 
 Let's say you want to create a subclass, maybe
 to [help with Apex unit tests][1]. Regardless of the reason,
-you want to know with certainty: When the subclass instance is cast
+you want to know with certainty: If the subclass instance is cast
 as the superclass, does the overridden method in the subclass still
 get executed when called?
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,18 @@ At the conclusion of this chain of events, we have the following.
 * **Rerun** showing `false` on the Apex Truth 1 record
 
 Run `ApexTruth1Test` to confirm these outcomes.
+
+## Truth 2
+
+> The overridden method in a subclass is always executed when invoked,
+even when the subclass instance is cast as the superclass
+
+Let's say you want to create a subclass, maybe
+to [help with Apex unit tests][1]. Regardless of the reason,
+you want to know with certainty: When the subclass instance is cast
+as the superclass, does the overridden method in the subclass still
+get executed when called?
+
+The `ApexTruth2MegaserviceTest.getName` test proves that the overridden
+method in the subclass is _always_ executed, even when the subclass instance
+is explicitly cast as the superclass.

--- a/force-app/main/default/classes/ApexTruth2Megaservice.cls
+++ b/force-app/main/default/classes/ApexTruth2Megaservice.cls
@@ -1,0 +1,13 @@
+public class ApexTruth2Megaservice extends ApexTruth2Service {
+    public ApexTruth2Megaservice() {
+        /* do nothing */
+    }
+
+    public override String getName() {
+        return ApexTruth2Megaservice.class.getName();
+    }
+
+    public String getMessage() {
+        return 'Megaservice says hello';
+    }
+}

--- a/force-app/main/default/classes/ApexTruth2Megaservice.cls-meta.xml
+++ b/force-app/main/default/classes/ApexTruth2Megaservice.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApexTruth2Megaservice">
+    <apiVersion>42.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ApexTruth2MegaserviceTest.cls
+++ b/force-app/main/default/classes/ApexTruth2MegaserviceTest.cls
@@ -10,15 +10,23 @@ private class ApexTruth2MegaserviceTest {
     private static void getName() {
 
         // Given
-        ApexTruth2Megaservice apexTruth2 = new ApexTruth2Megaservice();
+        ApexTruth2Megaservice apexTruth2Mega = new ApexTruth2Megaservice();
 
-        System.assertEquals('ApexTruth2Megaservice', apexTruth2.getName(),
-                '`name` property as `ApexTruth2Megaservice` instance');
+        System.assertEquals(
+                'ApexTruth2Service',
+                new ApexTruth2Service().getName(),
+                '`name` property of `ApexTruth2Service` instance');
+
+        System.assertEquals(
+                'ApexTruth2Megaservice',
+                apexTruth2Mega.getName(),
+                '`name` property of `ApexTruth2Megaservice` instance');
 
         // When
         Test.startTest();
 
-        String name = ((ApexTruth2Service)apexTruth2).getName();
+        ApexTruth2Service apexTruth2 = (ApexTruth2Service)apexTruth2Mega;
+        String name = apexTruth2.getName();
 
         // Then
         Test.stopTest();
@@ -28,7 +36,9 @@ private class ApexTruth2MegaserviceTest {
         System.assertEquals('ApexTruth2Megaservice', name,
                 '`name` property after casting instance as `ApexTruth2Service`');
         
-        System.assertEquals('Megaservice says hello', apexTruth2.getMessage(),
+        System.assertEquals(
+                'Megaservice says hello',
+                apexTruth2Mega.getMessage(),
                 '`message` property on original instance');
     }
 }

--- a/force-app/main/default/classes/ApexTruth2MegaserviceTest.cls
+++ b/force-app/main/default/classes/ApexTruth2MegaserviceTest.cls
@@ -1,0 +1,34 @@
+@isTest
+private class ApexTruth2MegaserviceTest {
+
+    /**
+     * This test proves that an overridden method in a subclass will always
+     * execute the method as defined in the subclass, even when the method
+     * is invoked after casting an instance of the subclass as the superclass.
+     */
+    @isTest
+    private static void getName() {
+
+        // Given
+        ApexTruth2Megaservice apexTruth2 = new ApexTruth2Megaservice();
+
+        System.assertEquals('ApexTruth2Megaservice', apexTruth2.getName(),
+                '`name` property as `ApexTruth2Megaservice` instance');
+
+        // When
+        Test.startTest();
+
+        String name = ((ApexTruth2Service)apexTruth2).getName();
+
+        // Then
+        Test.stopTest();
+
+        // Prove that `getName` still returns the same value as expected
+        // from the overridden subclass method
+        System.assertEquals('ApexTruth2Megaservice', name,
+                '`name` property after casting instance as `ApexTruth2Service`');
+        
+        System.assertEquals('Megaservice says hello', apexTruth2.getMessage(),
+                '`message` property on original instance');
+    }
+}

--- a/force-app/main/default/classes/ApexTruth2MegaserviceTest.cls-meta.xml
+++ b/force-app/main/default/classes/ApexTruth2MegaserviceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApexTruth2MegaserviceTest">
+    <apiVersion>42.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ApexTruth2Service.cls
+++ b/force-app/main/default/classes/ApexTruth2Service.cls
@@ -1,0 +1,9 @@
+public virtual class ApexTruth2Service {
+    public ApexTruth2Service() {
+        /* do nothing */
+    }
+
+    public virtual String getName() {
+        return ApexTruth2Service.class.getName();
+    }
+}

--- a/force-app/main/default/classes/ApexTruth2Service.cls-meta.xml
+++ b/force-app/main/default/classes/ApexTruth2Service.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApexTruth2Service">
+    <apiVersion>42.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
The overridden method in a subclass is always executed when invoked, even when the subclass instance is cast as the superclass